### PR TITLE
ElasticsearchのImageを7.16.2にアップグレード

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,24 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.7.0
-RUN elasticsearch-plugin install analysis-kuromoji
-RUN elasticsearch-plugin install analysis-icu
+#
+# OSSは x-pack がデフォルトで入っていない為そちらを利用したいが、
+# 7.10以降が出ていないため oss ではない方を利用している。
+#
+# 必要な Plugins がある為Dockerfileとして定義しています
+# https://www.docker.elastic.co/r/elasticsearch/elasticsearch
+# https://www.docker.elastic.co/r/elasticsearch/elasticsearch-oss
+#
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.2
+
+#
+# analysis-kuromoji: 日本語解析用
+#                    https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-kuromoji.html
+#
+# analysis-icu: アジア言語のより優れた分析、Unicode正規化、Unicode対応の大文字小文字の区別、照合サポート、および文字変換が含まれます
+#               https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html
+#
+RUN elasticsearch-plugin install analysis-kuromoji && \
+    elasticsearch-plugin install analysis-icu
+
+# x-pack の無効化
+RUN elasticsearch-plugin remove x-pack
+
+USER elasticsearch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
 #
-# OSSは x-pack がデフォルトで入っていない為そちらを利用したいが、
-# 7.10以降が出ていないため oss ではない方を利用している。
-#
 # 必要な Plugins がある為Dockerfileとして定義しています
 # https://www.docker.elastic.co/r/elasticsearch/elasticsearch
 # https://www.docker.elastic.co/r/elasticsearch/elasticsearch-oss
@@ -17,8 +14,5 @@ FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.2
 #
 RUN elasticsearch-plugin install analysis-kuromoji && \
     elasticsearch-plugin install analysis-icu
-
-# x-pack の無効化
-RUN elasticsearch-plugin remove x-pack
 
 USER elasticsearch


### PR DESCRIPTION
## 概要

表題のとおりです。
imageを7.16.2にアップグレードしています。

コメントの方にも記載していますが、OSSバージョンを利用したかったのですが
7.10系以降出ていない為ノーマルの方を利用しています。

https://www.docker.elastic.co/r/elasticsearch/elasticsearch-oss

x-packの削除とUSERの指定を追加しています。

### Imageについて

`6.7.0 -> 7.16.2`

これはdevに立っているバージョンと同じバージョンを指定しています。

![image](https://user-images.githubusercontent.com/19791597/156692147-3db91794-830c-48a7-b875-77ae6869a5d9.png)


### x-packについて

x-packを入れてしまうとSSLが必須であったりと少々面倒だったりするので削除をしています。

### USERの指定について

USERの指定に関してはデフォルトで適用されるので明記しなくても問題はないと思います。
https://www.elastic.co/guide/en/elasticsearch/reference/7.16/docker.html#_configuration_files_must_be_readable_by_the_elasticsearch_user