### PR TITLE
ElasticsearchのImageを7.17.2にアップグレード 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.7.0
-RUN elasticsearch-plugin install analysis-kuromoji
-RUN elasticsearch-plugin install analysis-icu
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.2
+
+RUN elasticsearch-plugin install analysis-kuromoji && \
+    elasticsearch-plugin install analysis-icu
+
+USER elasticsearch


### PR DESCRIPTION
```
docker build -t elasticsearch_7.17.2 .
```

```
docker tag elasticsearch_7.17.2 andpad/elasticsearch_with_kuromoji:7.17.2
```

```
docker push andpad/elasticsearch_with_kuromoji:7.17.2
```

=> https://hub.docker.com/repository/docker/andpad/elasticsearch_with_kuromoji