### PR TITLE
ElasticsearchのImageを8.9.0にアップグレード

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.2
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.9.0
 
 RUN elasticsearch-plugin install analysis-kuromoji && \
     elasticsearch-plugin install analysis-icu


### PR DESCRIPTION
```
docker build -t elasticsearch_8.9.0 .
```

```
docker tag elasticsearch_8.9.0 andpad/elasticsearch_with_kuromoji:8.9.0
```

```
docker push andpad/elasticsearch_with_kuromoji:8.9.0
```

=> https://hub.docker.com/repository/docker/andpad/elasticsearch_with_kuromoji